### PR TITLE
Patch to allow build with EAOs openGL version

### DIFF
--- a/Rendering/OpenGL/vtkXOpenGLRenderWindow.cxx
+++ b/Rendering/OpenGL/vtkXOpenGLRenderWindow.cxx
@@ -28,6 +28,13 @@
 // define GLX_GLXEXT_LEGACY to prevent glx.h to include glxext.h provided by
 // the system
 //#define GLX_GLXEXT_LEGACY
+// New Workaround:
+// The GLX_GLXEXT_LEGACY definition was added to work around system glxext.h
+// files that used the GLintptr and GLsizeiptr types, but did not define them.
+// However, this broke multisampling (See PR#15433). Instead of using that
+// define, we're just defining the missing typedefs here.
+typedef ptrdiff_t GLintptr;
+typedef ptrdiff_t GLsizeiptr;
 #include "GL/glx.h"
 
 #include "vtkgl.h"


### PR DESCRIPTION
Since a recent OpenGL update, EAO's Centos 6 Starlink builds have been
failing when building vtk due to underclared values in glxext.h This
patch copies a fix from the current upstream to allow vtk to be built
again.

The error message which occurs is:
thirdparty/kitware/vtk/VTK/Rendering/OpenGL/vtkXOpenGLRenderWindow.cxx:31
/usr/include/GL/glxext.h:480: error: 'GLintptr' has not been declared
/usr/include/GL/glxext.h:480: error: 'GLintptr' has not been declared
/usr/include/GL/glxext.h:480: error: 'GLsizeiptr' has not been declared
/usr/include/GL/glxext.h:481: error: 'GLintptr' has not been declared
/usr/include/GL/glxext.h:481: error: 'GLintptr' has not been declared
/usr/include/GL/glxext.h:481: error: 'GLsizeiptr' has not been declared
make[4]: **\* [Rendering/OpenGL/CMakeFiles/vtkRenderingOpenGL.dir/vtkXOpenGLRenderWindow.cxx.o] Error 1
make[3]: **\* [Rendering/OpenGL/CMakeFiles
